### PR TITLE
ローカルでの`docker-compose up`がコケる問題を修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,16 @@ jobs:
             pwd && ls
 
       - run:
+          name: Set Environment Variables
+          command: |
+            touch .env
+            echo POSTGRES_USER=$POSTGRES_USER > .env
+            echo POSTGRES_PASSWORD=$POSTGRES_PASSWORD > .env
+            echo POSTGRES_DB=$POSTGRES_DB > .env
+            echo POSTGRES_PORT=$POSTGRES_PORT > .env
+            cat .env
+
+      - run:
           name: Build Docker container
           command: |
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Confirm directory state
           command: |
             set -x
-            pwd && ls && ls db/
+            pwd && ls -a && ls db/
 
       - run:
           name: Build Docker container
@@ -36,7 +36,11 @@ jobs:
             set -x
             docker-compose up -d
             docker-compose run --rm db sh -c "psql --version"
-            sleep 10
+            docker-compose exec db bash
+            sleep 5
+            psql -U {$POSTGRES_USER}
+            sleep 5
+            exit
             docker ps -f status=running
             docker-compose logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,7 @@ jobs:
             set -x
             docker-compose up -d
             docker-compose run --rm db sh -c "psql --version"
-            docker-compose exec db bash
             sleep 5
-            psql -U {$POSTGRES_USER}
-            sleep 5
-            exit
             docker ps -f status=running
             docker-compose logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,26 +4,25 @@ jobs:
     machine:
       image: ubuntu-1604:202007-01
 
-    working_directory: ~/db
-
     steps:
       - checkout
+
+      - run:
+          name: Set Environment Variables for docker-compose
+          command: |
+            set -x
+            touch .env
+            echo POSTGRES_USER=$POSTGRES_USER >> .env
+            echo POSTGRES_PASSWORD=$POSTGRES_PASSWORD >> .env
+            echo POSTGRES_DB=$POSTGRES_DB >> .env
+            echo POSTGRES_PORT=$POSTGRES_PORT >> .env
+            cat .env
 
       - run:
           name: Confirm directory state
           command: |
             set -x
-            pwd && ls
-
-      - run:
-          name: Set Environment Variables
-          command: |
-            touch .env
-            echo POSTGRES_USER=$POSTGRES_USER > .env
-            echo POSTGRES_PASSWORD=$POSTGRES_PASSWORD > .env
-            echo POSTGRES_DB=$POSTGRES_DB > .env
-            echo POSTGRES_PORT=$POSTGRES_PORT > .env
-            cat .env
+            pwd && ls && ls db/
 
       - run:
           name: Build Docker container

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_DB=testdb
+
+POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -2,6 +2,62 @@
 
 [![miolab](https://circleci.com/gh/miolab/psql_docker_sandbox.svg?style=svg)](https://github.com/miolab/psql_docker_sandbox)
 
-PostgreSQL コンテナ構築検証用リポジトリ
+PostgreSQL コンテナ構築 & 起動検証用リポジトリ
+
+---
+
+### 公式
 
 - Docker Hub https://hub.docker.com/_/postgres
+
+  - alpine image
+
+    (docker) https://hub.docker.com/layers/postgres/library/postgres/alpine/images/sha256-1dfcbfea3e85ad81b7baef84a68c8d8f8676a6b400d1ff0790929bfe1bd6d9df?context=explore
+
+    (GitHub) https://github.com/docker-library/postgres/blob/04bf35f0c4a3f7ac41591f9b28e2de1fecb7fef4/12/alpine/Dockerfile
+
+    (Docker docs) https://docs.docker.jp/engine/examples/postgresql_service.html
+
+- GitHub https://github.com/docker-library/docs/blob/master/postgres/README.md
+
+---
+
+### 参考
+
+- 永続化
+
+  https://crudzoo.com/blog/docker-postgres
+
+  https://qiita.com/ko-da-k/items/47b96883144a5bf1cb1e
+
+  https://hiroki-sawano.hatenablog.com/entry/populate-postgres-container
+
+- トラブルシュート
+
+  https://github.com/BCDevOps/openshift-wiki/wiki/Postgresql---unexpected-data-beyond-EOF-in-block
+
+  https://daichan.club/container/78908
+
+  https://teratail.com/questions/247008
+
+  https://qiita.com/shota0701nemoto/items/696393028fe77bf356bb
+
+  https://qiita.com/tomokazu0112/items/ecb26cf89b575a036f0f
+
+  https://teratail.com/questions/224610
+
+- その他（alpine image, etc.）
+
+  https://qiita.com/pottava/items/970d7b5cda565b995fe7
+
+  https://sasapyond.hatenablog.com/entry/2018/11/12/013454
+
+  https://qiita.com/at-946/items/c69a512ea47941747b18
+
+  https://qiita.com/sey323/items/a4875408a67cea6a8c52
+
+  https://blog.imind.jp/entry/2019/02/15/180512
+
+  https://github.com/iktakahiro/sql-basic-book/blob/master/docs/docker-postgres.md
+
+  https://qiita.com/hoto17296/items/070857971f95017b5e07

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,5 +1,3 @@
 FROM postgres:12-alpine
 
 ENV LANG ja_JP.utf8
-EXPOSE 5432
-CMD ["postgres"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,5 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./db/data/postgres:/var/lib/postgresql/data
+      - ./db/postgres/tmp/data:/var/lib/postgresql/data
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   db:
     build: ./db
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=testdb
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:5432"
     volumes:
       - ./db/postgres/tmp/data:/var/lib/postgresql/data
     restart: always


### PR DESCRIPTION
現状、ローカル開発環境（macOS）において、 `docker-compose up` でのPostgresコンテナ起動が失敗するケースが発生しているため、これを解決する

1.
  - クラウド環境（Linux）
  - CIビルド
  では問題なくビルド成功しているので、ローカルでも起動できるよう微修正を加えていく

2.
上記1.事情があるため、既存ファイルにはなるべく手をつけず（最小限の修正で）問題解決できるよう改善実装する